### PR TITLE
feat(lb): 账号并发上限可配 + 全部断开重连 + 会话临近过期平滑切换

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,3 +107,5 @@ docker build .
 - [x] 多账号池 + **热 session 优先调度**（无 conversation 粘性；同模型串行/并发均复用；冷启动只 admit 一次；新模型优先空闲账号）+ Flash/MiMo 实时每日配额 + **全链路故障转移**（chat/run/网络错误都换号，试完所有账号才报错；capacity_deferred 不冷却；gate 同号重试后升级换号）
 - [x] 前端「代理设置」全局池管理：多行代理、保存立即生效、持久化 `/data/proxies.json`、重启自动加载、无需重启
 - [x] 全局代理池（config 层兜底）+ 代理测试（出口 IP/国家/延迟/codebuff 状态、底层原因码）+ 账号级 proxy 仅内部字段（无 UI）
+- [x] **账号并发上限可配**（控制台「负载均衡设置」，默认 1:1；1..16，保存立即生效）+ 总览每账号「并发(在途/上限)」监控 + **会话临近过期提前 re-admit**（`session.re_admit_lead_sec`，默认 60s）平滑切换，流 idle 超时按会话剩余时间收敛
+- [x] 前端「**全部断开重连**」（admin，`POST /api/system/reconnect`）：释放全部 session + 重置并发信号量，比重启更轻量；下个请求自动 re-admit

--- a/README.md
+++ b/README.md
@@ -167,9 +167,15 @@ Freebuff 免费会话是**无状态**的：上游每次请求都会收到**全�
 **最少新建 session**的目标调度：
 
 - 优先复用同模型的活跃 session；`conversation_id` / `thread_id` / `user` / `client_id` 不参与选号；
-- **账号级串行化**：一个账号同一时间只处理一个 chat（上游会话不稳定时并发容易互相
-  干扰/顶号）。并发请求会按热 session 排队，而不是同时打在同一个 `instanceId` 上；
-  排队超时（`limits.account_chat_wait_ms`）后会换到下一个可用账号；
+- **账号并发上限可配**：默认 1:1（一个账号同一时间只转发一条 SSE 流）。可在控制台
+  「负载均衡设置」调整（1..16），实测同一 `instanceId` 支持多条并发 chat 流，调大后
+  一个账号可同时转发多条响应；达到上限的请求按热 session 排队，超时
+  （`limits.account_chat_wait_ms`）后换到下一个可用账号。总览里每个账号显示
+  `并发(在途/上限)` 实时监控；
+- **会话临近过期提前切换**：剩余时间低于 `session.re_admit_lead_sec`（默认 60s）的
+  会话不再承接新请求，先释放再 re-admit 换全新会话——避免请求发到马上过期的会话上、
+  中途卡住（响应明显变慢/挂起）；流式 idle 超时也会按会话剩余时间收敛，过期后上游
+  若不再吐数据会更快被掐断；
 - 冷启动的选号与 admit 已原子化：多个并发请求同时到达也只创建一个 session；
 - 没有同模型热 session 时，优先选择没有活跃 session 的账号，避免提前释放其他模型的可用时段；
 - 多个同层级账号只在平局时轮询；**冷却中的账号跳过**；
@@ -213,6 +219,16 @@ Freebuff 免费层按 **模型 × 每日** 限次（上游返回 `rateLimitsByMo
 - 断开后**不冷却该账号**（session 本身可能正常，只是那次传输卡了），下一个请求仍可
   复用同一 session；账号级串行化保证同一个账号不会同时被多个卡死请求叠加占用；
 - 后台控制面请求（session / agent-runs 等）的 body 读取同样带超时兜底，杜绝任何路径挂死。
+
+### 前端一键「全部断开重连」（轻量兜底）
+
+右上角管理员专属「**全部断开重连**」按钮（`POST /api/system/reconnect`）：**比重启更轻量**，
+进程不重启，仅释放全部账号的 session（上游 DELETE）并重置账号并发信号量（清空在途计数、
+放行排队等待者）。用于清理死任务/幽灵连接等异常状态：
+
+- 正在传输的 SSE 可能被中断，但**下一个请求会自动 re-admit 全新 session**，无需任何手动操作；
+- Web 登录态、账号、代理池等全部保持不变；
+- 权限：仅 admin 角色可调（非登录返回 401，非 admin 返回 403）。
 
 ### 前端一键「重启服务」（终极兜底）
 
@@ -339,6 +355,8 @@ Docker 部署时配置位于 `/data/config.yaml`（首次启动自动生成，�
 | 监听地址 | `server.host` / `port`（`FREEBUFF_PROXY_HOST` / `FREEBUFF_PROXY_PORT` 覆盖） |
 | 管理员 | `ADMIN_USERNAME` / `ADMIN_PASSWORD`（或 `users.default_admin_*`） |
 | 并发上限 | `limits.max_concurrent_requests` |
+| 每账号并发（SSE 流数） | `limits.account_max_concurrency`（默认 1，控制台「负载均衡设置」实时调整） |
+| 会话过期提前切换 | `session.re_admit_lead_sec`（默认 60s） |
 | 上游流 idle 超时（幽灵连接治理） | `limits.stream_idle_timeout_sec`（默认 120s） |
 | 账号级串行化排队上限 | `limits.account_chat_wait_ms`（默认 120000ms） |
 | Web 会话有效期 | `web.session_ttl_hours`（默认 168h） |

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -113,7 +113,10 @@ async function main() {
     return
   }
 
-  const ctx = buildAppContext(config)
+  const ctx = buildAppContext(config, {
+    // 账号并发上限来自控制台设置（/data/settings.json，默认 1:1），实时生效
+    getAccountConcurrency: () => settingsStore.get().accountMaxConcurrency,
+  })
   if (ctx.authEmail) {
     logger.info('upstream auth ready', {
       account: ctx.authEmail,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -37,11 +37,17 @@ users:
 session:
   release_on_shutdown: true
   re_admit_on_expire: true
+  # 会话剩余时间低于该值（秒）时不再承接新请求，提前 re-admit 换新会话，
+  # 避免请求发到马上过期的会话上、中途卡住（切换流量更平滑）
+  re_admit_lead_sec: 60
   poll_interval_sec: 30
   admit_timeout_ms: 30000
 
 limits:
   max_concurrent_requests: 32
+  # 每个账号同一时间最多转发的 SSE 响应流数（账号并发，默认 1:1）。
+  # 建议在控制台「负载均衡设置」里调整，保存立即生效、无需重启
+  account_max_concurrency: 1
   upstream_timeout_sec: 600
   # 上游流式响应 body idle 超时（秒）：上游发了响应头后长时间不再吐数据
   # （幽灵连接）→ 主动掐断/换号，避免连接永远挂着。

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -103,6 +103,11 @@ function renderHeader() {
   if (state.me.role === 'admin') {
     buttons.push(el('button', {
       class: 'danger',
+      onclick: reconnectAll,
+      title: '比重启更轻量：释放全部 session、清理死任务，下个请求自动重建（不重启进程）',
+    }, '全部断开重连'))
+    buttons.push(el('button', {
+      class: 'danger',
       onclick: restartService,
       title: '彻底解决连接卡死等问题：重启整个代理服务（约几秒）',
     }, '重启服务'))
@@ -114,6 +119,22 @@ function renderHeader() {
     el('span', { class: 'muted' }, `👤 ${state.me.username} ${state.me.role === 'admin' ? el('span', { class: 'badge admin' }, 'admin') : ''}`),
     ...buttons,
   ])
+}
+
+/**
+ * 前端「全部断开重连」：请求 API → 服务端释放所有账号 session 并重置并发信号量。
+ * 比重启轻量（进程不重启），用于清理死任务/幽灵连接；下个请求自动重建 session。
+ */
+async function reconnectAll() {
+  if (!confirm('确定要全部断开重连吗？\n\n将释放所有账号的 session（正在传输的 SSE 可能被中断），下一个请求会自动重建新 session。')) return
+  try {
+    const r = await api('/api/system/reconnect', { method: 'POST' })
+    const failed = (r.accounts || []).filter((x) => !x.ok)
+    toast(failed.length ? `已断开重连，${failed.length} 个账号失败` : '已全部断开重连，下个请求自动重建')
+    render()
+  } catch (err) {
+    toast(err.message, true)
+  }
 }
 
 /**
@@ -222,7 +243,7 @@ async function renderOverview(view) {
         el('div', { class: 'row spread' }, [
           el('div', {}, [
             el('span', { class: 'muted' }, `负载均衡 · 共 ${totalReq} 次选号 `),
-            el('span', { class: 'muted' }, '（会话级：不同会话按哈希摊开，同一会话固定账号；配额感知仅限额模型生效）'),
+            el('span', { class: 'muted' }, '（热 session 优先复用，同一账号可配置并发上限；配额感知仅限额模型生效）'),
           ]),
           el('button', { class: 'muted', onclick: () => render() }, '刷新'),
         ]),
@@ -231,7 +252,7 @@ async function renderOverview(view) {
     }
 
     const table = el('table', {}, [
-      el('thead', {}, el('tr', {}, ['账号', '状态', 'Session', '额度（今日）', '请求', '冷却', '操作'].map((t) => el('th', {}, t)))),
+      el('thead', {}, el('tr', {}, ['账号', '状态', 'Session', '并发(在途/上限)', '额度（今日）', '请求', '冷却', '操作'].map((t) => el('th', {}, t)))),
       el('tbody', {}, data.accounts.map((a) => {
         const cd = a.cooldownUntil ? new Date(a.cooldownUntil).toLocaleString() : null
         const sess = a.session?.live
@@ -249,6 +270,7 @@ async function renderOverview(view) {
             ? el('span', { class: 'badge ok' }, '可用')
             : el('span', { class: 'badge err' }, cd ? `冷却至 ${cd}` : '冷却中')),
           el('td', { class: 'mono' }, sess),
+          el('td', { class: 'mono' }, `${a.inFlight || 0}/${a.concurrency || 1}`),
           el('td', {}, fmtQuota(a.quota)),
           el('td', { class: 'mono' }, `${a.requests || 0} 次`),
           el('td', {}, cd ? el('span', { class: 'badge warn' }, a.cooldownCode || 'cooldown') : '—'),
@@ -317,6 +339,34 @@ async function renderProxySettings(view) {
     ]),
   ]))
 
+  // 负载均衡：每账号并发上限（1:1 默认；一个账号可同时转发多条 SSE 流）
+  const concurrency = settings.accountMaxConcurrency ?? 1
+  view.append(el('div', { class: 'card', style: 'margin-top:12px' }, [
+    el('div', { class: 'row spread' }, [
+      el('div', {}, [
+        el('h3', { style: 'margin:0 0 2px' }, '负载均衡设置'),
+        el('span', { class: 'muted' }, '每个账号同一时间最多转发的 SSE 响应流数（默认 1:1，一个账号一个并发）；保存立即生效，无需重启'),
+      ]),
+      el('div', { class: 'row' }, [
+        el('input', {
+          id: 'account-concurrency',
+          type: 'number',
+          min: 1,
+          max: 16,
+          style: 'width:70px',
+          value: concurrency,
+          ...(state.me.role === 'admin' ? {} : { disabled: '' }),
+        }),
+        state.me.role === 'admin'
+          ? el('button', { class: 'primary', onclick: saveAccountConcurrency }, '保存并生效')
+          : null,
+      ]),
+    ]),
+    state.me.role !== 'admin'
+      ? el('div', { class: 'muted', style: 'margin-top:8px' }, `当前每账号并发上限：${concurrency}（管理员可调）`)
+      : null,
+  ]))
+
   const card = el('div', { class: 'card', style: 'margin-top:12px' }, [
     el('div', { class: 'row spread' }, [
       el('div', {}, [
@@ -364,6 +414,26 @@ async function saveFreeToolSignatureSetting(event) {
   } catch (err) {
     input.checked = !enabled
     input.disabled = false
+    toast(err.message, true)
+  }
+}
+
+async function saveAccountConcurrency() {
+  const input = $('#account-concurrency')
+  if (!input) return
+  const n = Number(input.value)
+  if (!Number.isInteger(n) || n < 1 || n > 16) {
+    toast('并发数必须是 1..16 的整数', true)
+    return
+  }
+  try {
+    const r = await api('/api/settings', {
+      method: 'POST',
+      body: JSON.stringify({ accountMaxConcurrency: n }),
+    })
+    toast(`每账号并发上限已设为 ${r.accountMaxConcurrency}，立即生效`)
+    render()
+  } catch (err) {
     toast(err.message, true)
   }
 }

--- a/src/app-context.js
+++ b/src/app-context.js
@@ -38,21 +38,55 @@ const DEFAULT_COOLDOWN_MS = 60_000
 const BANNED_COOLDOWN_MS = DAY_MS
 
 /**
- * 账号级串行化互斥锁（公平 FIFO + 有界等待）：
- * 一个账号同一时间只允许一个 chat 在途——上游会话不稳定时并发容易
- * 互相干扰/顶号（幽灵连接的诱因之一）。
+ * 账号级 chat 并发信号量（公平 FIFO + 有界等待）：
+ * 默认容量 1（一个账号同一时间只处理一个 chat，避免上游会话不稳定时
+ * 并发互相干扰/顶号）；可在控制台「负载均衡」调大（一个账号可同时
+ * 转发多个 SSE 响应流，实测同一 instanceId 支持并发 chat）。
  * timeoutMs=0 表示无限等待；持锁者受 streamIdleTimeoutSec / 各 HTTP 阶段
  * 超时约束，无限等待在实际运行中是有上界的。
  */
 class ChatMutex {
-  constructor() {
-    this._held = false
+  /**
+   * @param {number} [capacity] 同一账号最大并发 chat 数（>=1）
+   */
+  constructor(capacity = 1) {
+    this._capacity = Math.max(1, Math.floor(capacity) || 1)
+    /** 当前在途 chat 数（含已授予的等待者）。 */
+    this._held = 0
     /** @type {Array<{resolve: Function, reject: Function, timer: NodeJS.Timeout | null}>} */
     this._queue = []
   }
 
+  /** 是否已达到并发上限（不再有可用槽位）。 */
   get busy() {
+    return this._held >= this._capacity
+  }
+
+  /** 当前在途 chat 数（监控用）。 */
+  get inFlight() {
     return this._held
+  }
+
+  /** 当前并发上限（监控用）。 */
+  get capacity() {
+    return this._capacity
+  }
+
+  /**
+   * 动态调整并发上限（控制台保存后立即生效）。已授予的在途不受影响；
+   * 调大时立即把空出的槽位授予排队的等待者。
+   * @param {number} n
+   */
+  setCapacity(n) {
+    const next = Math.max(1, Math.floor(n) || 1)
+    if (next === this._capacity) return
+    this._capacity = next
+    while (this._queue.length && this._held < this._capacity) {
+      const entry = this._queue.shift()
+      if (entry.timer) clearTimeout(entry.timer)
+      this._held += 1
+      entry.resolve(this._makeRelease())
+    }
   }
 
   /**
@@ -75,8 +109,8 @@ class ChatMutex {
         }, timeoutMs)
         if (entry.timer.unref) entry.timer.unref()
       }
-      if (!this._held) {
-        this._held = true
+      if (this._held < this._capacity) {
+        this._held += 1
         if (entry.timer) clearTimeout(entry.timer)
         resolve(this._makeRelease())
       } else {
@@ -85,17 +119,31 @@ class ChatMutex {
     })
   }
 
+  /**
+   * 全部断开重连时调用：清空在途计数并立即放行所有排队等待者
+   * （等待者会在 chat 流程里重新检查 session 并 re-admit，不会卡死）。
+   */
+  reset() {
+    this._held = 0
+    while (this._queue.length) {
+      const entry = this._queue.shift()
+      if (entry.timer) clearTimeout(entry.timer)
+      this._held += 1
+      entry.resolve(this._makeRelease())
+    }
+  }
+
   _makeRelease() {
     let released = false
     return () => {
       if (released) return
       released = true
-      const next = this._queue.shift()
-      if (next) {
+      this._held = Math.max(0, this._held - 1)
+      while (this._queue.length && this._held < this._capacity) {
+        const next = this._queue.shift()
         if (next.timer) clearTimeout(next.timer)
+        this._held += 1
         next.resolve(this._makeRelease())
-      } else {
-        this._held = false
       }
     }
   }
@@ -109,10 +157,17 @@ class ChatMutex {
 export class AccountRuntimes {
   /**
    * @param {import('./config.js').ProxyConfig} config
+   * @param {{ getAccountConcurrency?: () => number }} [opts]
+   *   getAccountConcurrency: 每个账号的并发上限来源（控制台设置/配置），
+   *   默认取 config.limits.accountMaxConcurrency。
    */
-  constructor(config) {
+  constructor(config, opts = {}) {
     this.config = config
     this.dir = resolveCredentialsDir(config)
+    this._getAccountConcurrency =
+      typeof opts.getAccountConcurrency === 'function'
+        ? opts.getAccountConcurrency
+        : () => this.config.limits.accountMaxConcurrency || 1
     /** @type {Map<string, { key: string, email: string, id: string | null, authToken: string, user: any, upstream: any, sessions: SessionManager, source: string }>} */
     this.byKey = new Map()
     /**
@@ -137,6 +192,7 @@ export class AccountRuntimes {
       const cooling = Boolean(cd && cd.until > now)
       const rt = this.byKey.get(a.key)
       const snap = rt?.sessions?.getSnapshot?.()
+      const chatLock = this.chatLocks.get(a.key)
       return {
         ...a,
         lastUsed: this._lastSuccessKey === a.key,
@@ -144,6 +200,9 @@ export class AccountRuntimes {
         cooldownUntil: cooling ? new Date(cd.until).toISOString() : null,
         cooldownCode: cooling ? cd.code : null,
         requests: this.stats.byKey.get(a.key) || 0,
+        // 负载均衡监控：当前在途 SSE 流数 / 账号并发上限
+        inFlight: chatLock?.inFlight || 0,
+        concurrency: chatLock?.capacity || this._accountConcurrency(),
         effectiveProxy: rt?.effectiveProxy || null,
         session: snap
           ? {
@@ -212,22 +271,35 @@ export class AccountRuntimes {
     return listAccounts(this.dir).map((a) => a.key)
   }
 
+  /** 每个账号的当前并发上限（控制台设置，实时生效）。 */
+  _accountConcurrency() {
+    const n = this._getAccountConcurrency()
+    return Number.isFinite(n) && n >= 1 ? Math.min(16, Math.floor(n)) : 1
+  }
+
   chatLockFor(key) {
     let lock = this.chatLocks.get(key)
     if (!lock) {
-      lock = new ChatMutex()
+      lock = new ChatMutex(this._accountConcurrency())
       this.chatLocks.set(key, lock)
+    } else {
+      lock.setCapacity(this._accountConcurrency())
     }
     return lock
   }
 
-  /** 账号当前是否正在处理 chat（锁被持有）。 */
+  /** 账号当前是否已达到并发上限（无可用 chat 槽位）。 */
   isChatBusy(key) {
     return this.chatLocks.get(key)?.busy || false
   }
 
+  /** 账号当前在途 chat 数（监控用）。 */
+  chatInFlight(key) {
+    return this.chatLocks.get(key)?.inFlight || 0
+  }
+
   /**
-   * 获取账号的 chat 串行化锁。
+   * 获取账号的 chat 并发槽位。
    * @param {string} key
    * @param {number} timeoutMs 0 = 无限等待
    * @returns {Promise<() => void>}
@@ -341,19 +413,28 @@ export class AccountRuntimes {
       const sessions = this.byKey.get(key)?.sessions
       const usable = sessions?.isUsableForModel?.(model) === true
       const live = sessions?.hasLiveSlot?.() === true
-      const quota = sessions?.getSnapshot?.()?.quota?.byModel?.[model]
+      const snap = sessions?.getSnapshot?.()
+      const quota = snap?.quota?.byModel?.[model]
       const exhausted =
         !usable &&
         quota &&
         Number.isFinite(quota.limit) &&
         quota.limit > 0 &&
         (Number(quota.recentCount) || 0) >= quota.limit
+      const chatLock = this.chatLocks.get(key)
+      const inFlight = chatLock?.inFlight || 0
+      const capacity = chatLock?.capacity || this._accountConcurrency()
+      const sameModel = snap?.model === model
       candidates.push({
         key,
-        tier: usable ? 0 : live ? 2 : 1,
-        // 同一层级内优先空闲账号（一个账号一个并发；已有热 session 的账号
-        // 忙时仍允许排队，只是排在同层空闲账号之后）
-        busy: this.isChatBusy(key) ? 1 : 0,
+        // 同模型即将过期（live 但不可复用）≈ 冷账号：只需 re-admit 续期，
+        // 不应排到"要释放别的模型 session"的最后梯队
+        tier: usable ? 0 : live && !sameModel ? 2 : 1,
+        // 同模型过期时优先在同一账号 re-admit（保持出口稳定），而不是换账号新建
+        sameModel: sameModel ? 1 : 0,
+        // 达到并发上限的账号排后；同层级内优先在途少的账号
+        busy: inFlight >= capacity ? 1 : 0,
+        load: inFlight,
         exhausted: exhausted ? 1 : 0,
         rotation: i,
       })
@@ -361,7 +442,9 @@ export class AccountRuntimes {
     candidates.sort(
       (a, b) =>
         a.tier - b.tier ||
+        b.sameModel - a.sameModel ||
         a.busy - b.busy ||
+        a.load - b.load ||
         a.exhausted - b.exhausted ||
         a.rotation - b.rotation,
     )
@@ -582,6 +665,41 @@ export class AccountRuntimes {
     this.byKey.delete(key)
   }
 
+  /**
+   * 全部断开重连（比重启更轻量）：释放所有账号的 session（清理死任务），
+   * 并重置账号并发信号量（放行等待者，等待者会在 chat 流程重新 re-admit）。
+   * 不重启进程；下一个请求自动 admit 全新 session。
+   * @returns {Promise<Array<{key: string, email?: string, ok: boolean, error?: string}>>}
+   */
+  async reconnectAll() {
+    // 并发信号量与 runtime 的并集：无账号凭据的锁（如单元测试）也要重置
+    const keys = [...new Set([...this.chatLocks.keys(), ...this.byKey.keys()])]
+    const results = await Promise.all(
+      keys.map(async (key) => {
+        const rt = this.byKey.get(key)
+        try {
+          if (rt) await rt.sessions.release()
+          // 信号量重置：清空在途计数并放行排队等待者（等待者会在 chat
+          // 流程重新检查 session 并 re-admit，不会卡死）
+          this.chatLocks.get(key)?.reset()
+          return { key, email: rt?.email, ok: true }
+        } catch (err) {
+          return {
+            key,
+            email: rt?.email,
+            ok: false,
+            error: err instanceof Error ? err.message : String(err),
+          }
+        }
+      }),
+    )
+    logger.info('all sessions disconnected via web console', {
+      accounts: keys.length,
+      ok: results.filter((r) => r.ok).length,
+    })
+    return results
+  }
+
   /** 代理池变更后调用：释放并重建所有缓存 runtime，让新出口立即生效 */
   async invalidateProxies() {
     const tasks = [...this.byKey.values()].map((rt) => rt.sessions.shutdown())
@@ -600,9 +718,10 @@ export class AccountRuntimes {
 
 /**
  * @param {import('./config.js').ProxyConfig} config
+ * @param {{ getAccountConcurrency?: () => number }} [opts] 透传给 AccountRuntimes
  */
-export function buildAppContext(config) {
-  const runtimes = new AccountRuntimes(config)
+export function buildAppContext(config, opts = {}) {
+  const runtimes = new AccountRuntimes(config, opts)
   const keys = runtimes.allKeys()
   if (!keys.length) {
     // Zero-account startup is allowed: the web console can add Freebuff

--- a/src/config.js
+++ b/src/config.js
@@ -10,8 +10,8 @@ import { parse as parseYaml } from 'yaml'
  * @property {{apiBase: string, loginBase: string, credentialsDir: string | null, proxy: string | null, proxies: string[]}} upstream
  * @property {{cookieSecure: boolean, sessionTtlHours: number}} web
  * @property {{defaultAdminUsername: string, defaultAdminPassword: string | null}} users
- * @property {{releaseOnShutdown: boolean, reAdmitOnExpire: boolean, pollIntervalSec: number, admitTimeoutMs: number}} session
- * @property {{maxConcurrentRequests: number, upstreamTimeoutSec: number, streamIdleTimeoutSec: number, accountChatWaitMs: number, maxAutoRetryOnSessionError: number}} limits
+ * @property {{releaseOnShutdown: boolean, reAdmitOnExpire: boolean, reAdmitLeadSec: number, pollIntervalSec: number, admitTimeoutMs: number}} session
+ * @property {{maxConcurrentRequests: number, accountMaxConcurrency: number, upstreamTimeoutSec: number, streamIdleTimeoutSec: number, accountChatWaitMs: number, maxAutoRetryOnSessionError: number}} limits
  * @property {{level: 'debug' | 'info' | 'warn' | 'error'}} logging
  */
 
@@ -47,11 +47,17 @@ const DEFAULTS = {
   session: {
     releaseOnShutdown: true,
     reAdmitOnExpire: true,
+    // 会话剩余时间低于该值(秒)时不再承接新请求，提前 re-admit 换新会话，
+    // 避免请求发到马上过期的会话上、中途卡住（默认 60s）。
+    reAdmitLeadSec: 60,
     pollIntervalSec: 30,
     admitTimeoutMs: 30_000,
   },
   limits: {
     maxConcurrentRequests: 32,
+    // 每个账号同一时间最多可转发的 SSE 响应流数（账号并发）。默认 1:1
+    // （一个账号一个并发）；可在控制台「负载均衡」实时调整，立即生效。
+    accountMaxConcurrency: 1,
     upstreamTimeoutSec: 600,
     // 上游流式响应 body 的 idle 超时（秒）：收到响应头后若长时间没有新数据块，
     // 视为上游卡死（幽灵连接），主动掐断/换号，避免连接永远挂着。
@@ -79,9 +85,11 @@ const KEY_MAP = {
   default_admin_password: 'defaultAdminPassword',
   release_on_shutdown: 'releaseOnShutdown',
   re_admit_on_expire: 'reAdmitOnExpire',
+  re_admit_lead_sec: 'reAdmitLeadSec',
   poll_interval_sec: 'pollIntervalSec',
   admit_timeout_ms: 'admitTimeoutMs',
   max_concurrent_requests: 'maxConcurrentRequests',
+  account_max_concurrency: 'accountMaxConcurrency',
   upstream_timeout_sec: 'upstreamTimeoutSec',
   stream_idle_timeout_sec: 'streamIdleTimeoutSec',
   account_chat_wait_ms: 'accountChatWaitMs',

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -404,6 +404,8 @@ export function createProxyHandler(ctx) {
               forwardBody,
               stream,
               upstream: rt.upstream,
+              // 会话剩余时间：用于把流 idle 超时收敛到会话过期附近，过期即掐
+              sessionRemainingMs: snap.remainingMs,
             })
           }
 
@@ -582,12 +584,28 @@ export function createProxyHandler(ctx) {
     return body
   }
 
+  /**
+   * 流式 idle 超时：默认取 limits.streamIdleTimeoutSec；若会话剩余时间已知，
+   * 在其基础上加一个 lead 宽限并封顶，会话过期后上游若不再吐数据（幽灵卡死）
+   * 会更快被掐断，避免"会话快过期时响应卡住"。带下限 30s，避免误伤慢首包。
+   */
+  function effectiveStreamIdleMs(sessionRemainingMs) {
+    const base = (config.limits.streamIdleTimeoutSec || 0) * 1000
+    if (!(base > 0) || !Number.isFinite(sessionRemainingMs)) return base
+    const lead = 20_000
+    return Math.min(
+      base,
+      Math.max(30_000, Math.max(0, sessionRemainingMs) + lead),
+    )
+  }
+
   async function forwardCompletions({
     req,
     res,
     forwardBody,
     stream,
     upstream,
+    sessionRemainingMs,
   }) {
     const headers = {
       ...filterRequestHeaders(req.headers),
@@ -703,7 +721,7 @@ export function createProxyHandler(ctx) {
     }
     try {
       await pipeWebStreamToNode(upstreamRes.body, res, req, {
-        idleTimeoutMs: (config.limits.streamIdleTimeoutSec || 0) * 1000,
+        idleTimeoutMs: effectiveStreamIdleMs(sessionRemainingMs),
       })
       return { ok: true, wrote: true }
     } catch (err) {

--- a/src/session-manager.js
+++ b/src/session-manager.js
@@ -87,6 +87,15 @@ export class SessionManager {
     return false
   }
 
+  /**
+   * 会话剩余时间低于该阈值（秒）后不再承接新请求，提前 re-admit 换新会话，
+   * 避免请求发到马上过期的会话上、中途卡住（切换流量更平滑）。
+   */
+  reAdmitLeadMs() {
+    const sec = this.config.session.reAdmitLeadSec
+    return (Number.isFinite(sec) && sec > 0 ? sec : 60) * 1000
+  }
+
   isUsableForModel(model, session = this.session) {
     if (!this.hasLiveSlot(session)) return false
     if (!session?.model || !session.instanceId) return false
@@ -95,10 +104,16 @@ export class SessionManager {
       // instance disappears if reAdmit not needed mid-request
       return session.model === model
     }
-    if (session.expiresAt) {
-      const left = Date.parse(session.expiresAt) - Date.now()
-      // treat fully expired (past expiresAt) as needing re-admit for NEW work
-      if (left <= 0 && this.config.session.reAdmitOnExpire) return false
+    if (this.config.session.reAdmitOnExpire) {
+      // expiresAt 优先；上游只回 remainingMs 时用它兜底（admit 时的快照）。
+      const left =
+        session.expiresAt != null
+          ? Date.parse(session.expiresAt) - Date.now()
+          : typeof session.remainingMs === 'number'
+            ? session.remainingMs
+            : null
+      // 已过期 / 剩余时间不足 lead → 新请求需要 re-admit（提前平滑切换）
+      if (left != null && left <= this.reAdmitLeadMs()) return false
     }
     return session.status === 'active' && session.model === model
   }
@@ -119,14 +134,13 @@ export class SessionManager {
         return this.session
       }
 
-      // Different model while holding a slot → release first
-      if (
-        this.hasLiveSlot() &&
-        this.session?.model &&
-        this.session.model !== model
-      ) {
-        logger.info('switching freebuff session model', {
-          from: this.session.model,
+      // 持有的 slot 已不可用（模型不符 / 已过期 / 即将过期）：先释放再 admit，
+      // 平滑切换——避免带着旧 session 直接 POST 造成上游 model_locked 或排队。
+      if (this.hasLiveSlot() && !this.isUsableForModel(model)) {
+        logger.info('releasing session before re-admit', {
+          model,
+          status: this.session?.status,
+          from: this.session?.model,
           to: model,
         })
         await this._releaseUnlocked()

--- a/src/web/api.js
+++ b/src/web/api.js
@@ -116,6 +116,26 @@ export function createWebApi(deps) {
     const user = requireUser(req, res)
     if (!user) return true
 
+    if (method === 'POST' && path === '/api/system/reconnect') {
+      // 前端「全部断开重连」：比重启更轻量。释放所有账号 session、清理死任务，
+      // 下一个请求自动 admit 全新 session；进程不重启。
+      if (user.role !== 'admin') {
+        sendJson(res, 403, { error: '需要管理员权限' })
+        return true
+      }
+      logger.info('reconnect-all requested via web console', {
+        by: user.username,
+      })
+      const accounts = await runtimes.reconnectAll()
+      sendJson(res, 200, {
+        ok: true,
+        message:
+          '已断开全部 session，下次请求将自动重建；正在传输的连接可能被中断',
+        accounts,
+      })
+      return true
+    }
+
     if (method === 'POST' && path === '/api/system/restart') {
       // 前端「重启服务」：admin 专属，彻底解决幽灵连接等进程级问题。
       if (user.role !== 'admin') {
@@ -488,6 +508,7 @@ export function createWebApi(deps) {
       sendJson(res, 200, {
         freeToolSignatureEnabled:
           settingsStore?.get().freeToolSignatureEnabled !== false,
+        accountMaxConcurrency: settingsStore?.get().accountMaxConcurrency ?? 1,
       })
       return true
     }
@@ -508,15 +529,36 @@ export function createWebApi(deps) {
         sendJson(res, 400, { error: '无效的 JSON' })
         return true
       }
-      if (typeof body.freeToolSignatureEnabled !== 'boolean') {
+      const patch = {}
+      if (body.freeToolSignatureEnabled !== undefined) {
+        if (typeof body.freeToolSignatureEnabled !== 'boolean') {
+          sendJson(res, 400, {
+            error: 'freeToolSignatureEnabled 必须是布尔值',
+          })
+          return true
+        }
+        patch.freeToolSignatureEnabled = body.freeToolSignatureEnabled
+      }
+      if (body.accountMaxConcurrency !== undefined) {
+        if (
+          !Number.isInteger(body.accountMaxConcurrency) ||
+          body.accountMaxConcurrency < 1 ||
+          body.accountMaxConcurrency > 16
+        ) {
+          sendJson(res, 400, {
+            error: 'accountMaxConcurrency 必须是 1..16 的整数',
+          })
+          return true
+        }
+        patch.accountMaxConcurrency = body.accountMaxConcurrency
+      }
+      if (!Object.keys(patch).length) {
         sendJson(res, 400, {
-          error: 'freeToolSignatureEnabled 必须是布尔值',
+          error: '没有可保存的设置项',
         })
         return true
       }
-      const settings = settingsStore.save({
-        freeToolSignatureEnabled: body.freeToolSignatureEnabled,
-      })
+      const settings = settingsStore.save(patch)
       logger.info('runtime settings updated via web', settings)
       sendJson(res, 200, { ok: true, ...settings })
       return true

--- a/src/web/settings-store.js
+++ b/src/web/settings-store.js
@@ -3,6 +3,8 @@ import path from 'node:path'
 
 const DEFAULT_SETTINGS = Object.freeze({
   freeToolSignatureEnabled: true,
+  // 每个账号同一时间可并发的 SSE 响应流数（负载均衡），默认 1:1。
+  accountMaxConcurrency: 1,
 })
 
 /** Frontend-managed runtime settings persisted under /data. */
@@ -21,6 +23,11 @@ export class SettingsStore {
       if (typeof raw?.freeToolSignatureEnabled === 'boolean') {
         this.settings.freeToolSignatureEnabled = raw.freeToolSignatureEnabled
       }
+      if (Number.isInteger(raw?.accountMaxConcurrency)) {
+        this.settings.accountMaxConcurrency = clampConcurrency(
+          raw.accountMaxConcurrency,
+        )
+      }
     } catch (err) {
       console.error(
         `settings store load failed: ${err instanceof Error ? err.message : err}`,
@@ -32,14 +39,26 @@ export class SettingsStore {
     return { ...this.settings }
   }
 
-  /** @param {{ freeToolSignatureEnabled: boolean }} next */
+  /** @param {{ freeToolSignatureEnabled?: boolean, accountMaxConcurrency?: number }} next */
   save(next) {
-    if (typeof next?.freeToolSignatureEnabled !== 'boolean') {
-      throw new TypeError('freeToolSignatureEnabled must be a boolean')
+    if (next?.freeToolSignatureEnabled !== undefined) {
+      if (typeof next.freeToolSignatureEnabled !== 'boolean') {
+        throw new TypeError('freeToolSignatureEnabled must be a boolean')
+      }
+      this.settings.freeToolSignatureEnabled = next.freeToolSignatureEnabled
     }
-    const settings = {
-      freeToolSignatureEnabled: next.freeToolSignatureEnabled,
+    if (next?.accountMaxConcurrency !== undefined) {
+      if (
+        !Number.isInteger(next.accountMaxConcurrency) ||
+        next.accountMaxConcurrency < 1
+      ) {
+        throw new TypeError('accountMaxConcurrency must be an integer >= 1')
+      }
+      this.settings.accountMaxConcurrency = clampConcurrency(
+        next.accountMaxConcurrency,
+      )
     }
+    const settings = { ...this.settings }
     fs.mkdirSync(path.dirname(this.file), { recursive: true })
     const tmp = `${this.file}.tmp`
     fs.writeFileSync(
@@ -51,6 +70,11 @@ export class SettingsStore {
     this.settings = settings
     return this.get()
   }
+}
+
+/** 并发上限：1..16，防止误配造成上游顶号。 */
+function clampConcurrency(n) {
+  return Math.min(16, Math.max(1, n))
 }
 
 export { DEFAULT_SETTINGS }

--- a/test/smoke.mjs
+++ b/test/smoke.mjs
@@ -29,7 +29,10 @@ let calls = []
 /** @type {'ok' | 'gate_once' | 'rate_limit_a' | 'rate_limit_completion' | 'err_500_a' | 'capacity_once' | 'capacity_all' | 'run_500_a' | 'network_err_a' | 'gate_twice_a'} */
 let mockMode = 'ok'
 let sessionPosts = 0
+let sessionDeletes = 0
 let completionAttempts = 0
+/** 会话有效期（毫秒）：近过期/重连测试用 */
+let sessionExpiryMs = 3600_000
 
 globalThis.fetch = async (url, init = {}) => {
   const u = String(url)
@@ -80,8 +83,8 @@ globalThis.fetch = async (url, init = {}) => {
       instanceId: `inst-${sessionPosts}`,
       model,
       admittedAt: new Date().toISOString(),
-      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
-      remainingMs: 3600_000,
+      expiresAt: new Date(Date.now() + sessionExpiryMs).toISOString(),
+      remainingMs: sessionExpiryMs,
       accessTier: 'full',
       rateLimit,
       rateLimitsByModel: { [model]: rateLimit },
@@ -91,6 +94,7 @@ globalThis.fetch = async (url, init = {}) => {
     return jsonRes({ status: 'none', accessTier: 'full' })
   }
   if (u.includes('/api/v1/freebuff/session') && method === 'DELETE') {
+    sessionDeletes++
     return jsonRes({ status: 'none' })
   }
   if (u.includes('/api/v1/agent-runs') && method === 'POST') {
@@ -969,6 +973,42 @@ assert.equal(requireModelId(''), null)
         .freeToolSignatureEnabled,
       false,
     )
+  }
+  // 运行设置：账号并发上限（负载均衡）——默认 1，校验非法值，保存后持久化
+  {
+    const getDefault = await fetch(`http://127.0.0.1:${wport}/api/settings`, {
+      headers: { cookie },
+    })
+    assert.equal((await getDefault.json()).accountMaxConcurrency, 1)
+
+    for (const bad of [0, -1, 17, 1.5, 'x']) {
+      const res = await fetch(`http://127.0.0.1:${wport}/api/settings`, {
+        method: 'POST',
+        headers: { cookie, 'content-type': 'application/json' },
+        body: JSON.stringify({ accountMaxConcurrency: bad }),
+      })
+      assert.equal(res.status, 400, `accountMaxConcurrency=${bad} should be rejected`)
+    }
+
+    const save = await fetch(`http://127.0.0.1:${wport}/api/settings`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ accountMaxConcurrency: 4 }),
+    })
+    assert.equal(save.status, 200)
+    assert.equal((await save.json()).accountMaxConcurrency, 4)
+    assert.equal(settingsStore.get().accountMaxConcurrency, 4)
+    assert.equal(
+      new SettingsStore(path.join(wDir, 'settings.json')).get()
+        .accountMaxConcurrency,
+      4,
+    )
+    // 恢复默认，避免影响其他用例
+    await fetch(`http://127.0.0.1:${wport}/api/settings`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ accountMaxConcurrency: 1 }),
+    })
   }
   // 代理管理 API：GET 空池 → POST 保存（持久化 + 立即生效）→ GET 返回
   {
@@ -1909,6 +1949,328 @@ assert.equal(requireModelId(''), null)
   await scRuntimes.shutdown()
   scServer.close()
   fs.rmSync(scDir, { recursive: true, force: true })
+}
+
+// --- 账号并发上限：一个账号可同时转发 N 条 SSE 流（默认 1:1，可调大）---
+{
+  const ccDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fb-proxy-cc-'))
+  saveAccountUser(ccDir, { id: 'cca', email: 'cca@example.com', authToken: 'token-cca' })
+  saveAccountUser(ccDir, { id: 'ccb', email: 'ccb@example.com', authToken: 'token-ccb' })
+  const ccConfig = loadConfig()
+  ccConfig.server.host = '127.0.0.1'
+  ccConfig.server.port = 0
+  ccConfig.server.apiKeys = ['sk-test']
+  ccConfig.upstream.credentialsDir = ccDir
+  ccConfig.session.pollIntervalSec = 3600
+  ccConfig.limits.maxConcurrentRequests = 12
+  // 模拟控制台把每账号并发上限调到 2
+  const ccRuntimes = new AccountRuntimes(ccConfig, {
+    getAccountConcurrency: () => 2,
+  })
+  const ccServer = await startServer({
+    config: ccConfig,
+    runtimes: ccRuntimes,
+    ...(() => {
+      const rt = ccRuntimes.getAny()
+      return {
+        authToken: rt.authToken,
+        authSource: rt.source,
+        authEmail: rt.email,
+        upstream: rt.upstream,
+        sessions: rt.sessions,
+      }
+    })(),
+  })
+  const ccPort = ccServer.address().port
+
+  let streamActive = 0
+  let streamActiveMax = 0
+  const origFetch = globalThis.fetch
+  globalThis.fetch = async (url, init = {}) => {
+    const u = String(url)
+    if (u.includes('127.0.0.1') || u.includes('localhost')) return origFetch(url, init)
+    if (u.includes('/api/v1/chat/completions')) {
+      const body = JSON.parse(init.body)
+      if (body.stream) {
+        let closed = false
+        streamActive++
+        if (streamActive > streamActiveMax) streamActiveMax = streamActive
+        const stream = new ReadableStream({
+          start(controller) {
+            const enc = new TextEncoder()
+            const chunks = ['h', 'i', '!', '\n']
+            async function emit(i) {
+              if (i >= chunks.length || closed) {
+                streamActive = Math.max(0, streamActive - 1)
+                if (!closed) controller.close()
+                return
+              }
+              controller.enqueue(enc.encode(`data: {"x":"${chunks[i]}"}\n\n`))
+              await new Promise((r) => setTimeout(r, 100))
+              emit(i + 1)
+            }
+            emit(0)
+          },
+          cancel() {
+            closed = true
+            streamActive = Math.max(0, streamActive - 1)
+          },
+        })
+        return new Response(stream, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        })
+      }
+      return jsonRes({
+        id: 'c1', object: 'chat.completion',
+        choices: [{ message: { role: 'assistant', content: 'hi' } }],
+      })
+    }
+    return origFetch(url, init)
+  }
+
+  mockMode = 'ok'
+  sessionPosts = 0
+  completionAttempts = 0
+  const ccReqs = Array.from({ length: 6 }, () =>
+    fetch(`http://127.0.0.1:${ccPort}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer sk-test', 'content-type': 'application/json' },
+      body: JSON.stringify({
+        model: 'deepseek/deepseek-v4-flash',
+        stream: true,
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    }),
+  )
+  const ccResponses = await Promise.all(ccReqs)
+  const ccAccounts = []
+  for (const r of ccResponses) {
+    assert.equal(r.status, 200, await r.clone().text())
+    ccAccounts.push(r.headers.get('x-freebuff-proxy-account'))
+  }
+  // 并发上限 2：同一账号同一 session 同时最多 2 条流；全部 200、只 admit 一次
+  assert.equal(new Set(ccAccounts).size, 1, `expected one account, got ${JSON.stringify(ccAccounts)}`)
+  assert.equal(sessionPosts, 1, `expected 1 session admission, got ${sessionPosts}`)
+  assert.equal(streamActiveMax, 2, `expected max 2 concurrent streams, got ${streamActiveMax}`)
+  // 监控字段：账号行带 在途/上限
+  const ccRow = ccRuntimes.list().find((x) => x.email === 'cca@example.com')
+  assert.equal(ccRow.concurrency, 2)
+  assert.ok(Number.isInteger(ccRow.inFlight) && ccRow.inFlight <= 2)
+
+  globalThis.fetch = origFetch
+  await ccRuntimes.shutdown()
+  ccServer.close()
+  fs.rmSync(ccDir, { recursive: true, force: true })
+}
+
+// --- 会话临近过期：提前 re-admit 平滑切换（不再把新请求发到马上过期的会话）---
+{
+  const expDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fb-proxy-expire-'))
+  saveAccountUser(expDir, { id: 'ea', email: 'ea@example.com', authToken: 'token-ea' })
+  saveAccountUser(expDir, { id: 'eb', email: 'eb@example.com', authToken: 'token-eb' })
+  const expConfig = loadConfig()
+  expConfig.server.host = '127.0.0.1'
+  expConfig.server.port = 0
+  expConfig.server.apiKeys = ['sk-test']
+  expConfig.upstream.credentialsDir = expDir
+  expConfig.session.pollIntervalSec = 3600
+  const expRuntimes = new AccountRuntimes(expConfig)
+  const expServer = await startServer({
+    config: expConfig,
+    runtimes: expRuntimes,
+    ...(() => {
+      const rt = expRuntimes.getAny()
+      return {
+        authToken: rt.authToken,
+        authSource: rt.source,
+        authEmail: rt.email,
+        upstream: rt.upstream,
+        sessions: rt.sessions,
+      }
+    })(),
+  })
+  const expPort = expServer.address().port
+  const expChat = () => fetch(`http://127.0.0.1:${expPort}/v1/chat/completions`, {
+    method: 'POST',
+    headers: { authorization: 'Bearer sk-test', 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'deepseek/deepseek-v4-flash', messages: [{ role: 'user', content: 'hello' }] }),
+  })
+
+  mockMode = 'ok'
+  sessionPosts = 0
+  sessionDeletes = 0
+  completionAttempts = 0
+  // 会话有效期只有 30s < reAdmitLeadSec(60s)：第二个请求必须提前换新会话
+  sessionExpiryMs = 30_000
+  const e1 = await expChat()
+  assert.equal(e1.status, 200, await e1.clone().text())
+  assert.equal(sessionPosts, 1)
+  assert.equal(e1.headers.get('x-freebuff-proxy-account'), 'ea@example.com')
+  // 多账号场景：近过期会话在同一账号 re-admit 续期，而不是换到 eb 新建 session
+  const e2 = await expChat()
+  assert.equal(e2.status, 200, await e2.clone().text())
+  assert.equal(sessionPosts, 2, `近过期会话应提前 re-admit, got ${sessionPosts}`)
+  assert.ok(sessionDeletes >= 1, 're-admit 前应先释放旧会话')
+  assert.equal(e2.headers.get('x-freebuff-proxy-account'), 'ea@example.com')
+  assert.equal(
+    expRuntimes.list().find((x) => x.email === 'eb@example.com').requests,
+    0,
+    '近过期会话应在本账号续期，不换账号',
+  )
+
+  // 有效期恢复正常（1h > lead）后：e3 先把还差 30s 的旧会话换掉（第 3 次 admit），
+  // e4 起新会话剩余 1h，不再重复 admit
+  sessionExpiryMs = 3600_000
+  const e3 = await expChat()
+  assert.equal(e3.status, 200, await e3.clone().text())
+  assert.equal(sessionPosts, 3, `切换后的请求应 admit 一次, got ${sessionPosts}`)
+  const e4 = await expChat()
+  assert.equal(e4.status, 200, await e4.clone().text())
+  assert.equal(sessionPosts, 3, `正常有效期应复用会话, got ${sessionPosts}`)
+
+  sessionExpiryMs = 3600_000
+  await expRuntimes.shutdown()
+  expServer.close()
+  fs.rmSync(expDir, { recursive: true, force: true })
+}
+
+// --- 账号并发信号量单元测试：容量、排队、超时、动态调大 ---
+{
+  const capPool = new AccountRuntimes(loadConfig(), {
+    getAccountConcurrency: () => 2,
+  })
+  const r1 = await capPool.acquireChat('cap-key', 0)
+  const r2 = await capPool.acquireChat('cap-key', 0)
+  assert.equal(capPool.chatInFlight('cap-key'), 2)
+  assert.equal(capPool.isChatBusy('cap-key'), true)
+  // 满员时排队，超时 → account_busy
+  let timedOut = null
+  try {
+    await capPool.acquireChat('cap-key', 50)
+  } catch (err) {
+    timedOut = err
+  }
+  assert.equal(timedOut?.code, 'account_busy')
+  // 释放一个槽位 → 排队者立即获得
+  const waiting = capPool.acquireChat('cap-key', 500)
+  r2()
+  const r3 = await waiting
+  assert.equal(capPool.chatInFlight('cap-key'), 2)
+  // 动态调大容量 → 队列里再排的人立即获得
+  const waiting2 = capPool.acquireChat('cap-key', 500)
+  capPool.chatLockFor('cap-key').setCapacity(4)
+  const r4 = await waiting2
+  assert.equal(capPool.chatInFlight('cap-key'), 3)
+  r1(); r3(); r4()
+  assert.equal(capPool.chatInFlight('cap-key'), 0)
+  // 全部断开重连：重置信号量，在途清零、排队者放行
+  const r5 = await capPool.acquireChat('cap-key', 0)
+  const waiting3 = capPool.acquireChat('cap-key', 500)
+  await capPool.reconnectAll()
+  // 旧持有被清除；排队者被放行（已拿到槽位，会在 chat 流程重新 re-admit）
+  assert.ok(capPool.chatInFlight('cap-key') <= 1, 'reconnect 后旧持有应被清除')
+  const r6 = await waiting3
+  r5(); r6()
+  assert.equal(capPool.chatInFlight('cap-key'), 0)
+  await capPool.shutdown()
+}
+
+// --- 全部断开重连 API：比重启更轻量，释放 session + 重置并发信号量 ---
+{
+  const rcDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fb-proxy-reconnect-'))
+  saveAccountUser(rcDir, { id: 'ra', email: 'ra@example.com', authToken: 'token-ra' })
+  const rcConfig = loadConfig()
+  rcConfig.server.host = '127.0.0.1'
+  rcConfig.server.port = 0
+  rcConfig.server.apiKeys = ['sk-test']
+  rcConfig.upstream.credentialsDir = rcDir
+  rcConfig.session.pollIntervalSec = 3600
+  const { UserStore: RCUS } = await import('../src/web/user-store.js')
+  const { WebSessionStore: RCWS } = await import('../src/web/session-store.js')
+  const { LoginFlowManager: RCLFM } = await import('../src/web/login-flows.js')
+  const { ProxyStore: RCPS } = await import('../src/web/proxy-store.js')
+  const { SettingsStore: RCSS } = await import('../src/web/settings-store.js')
+  const rcUsers = new RCUS(path.join(rcDir, 'users.json'))
+  rcUsers.create({ username: 'admin', password: 'secret123', role: 'admin' })
+  rcUsers.create({ username: 'viewer', password: 'secret123', role: 'user' })
+  const rcWS = new RCWS(path.join(rcDir, 'web-sessions.json'), 3600_000)
+  const rcLFM = new RCLFM({ file: path.join(rcDir, 'login-flows.json'), credentialsDir: rcDir, config: rcConfig })
+  const rcPS = new RCPS(path.join(rcDir, 'proxies.json'))
+  const rcSS = new RCSS(path.join(rcDir, 'settings.json'))
+  const rcRuntimes = new AccountRuntimes(rcConfig)
+  const rcServer = await startServer({
+    config: rcConfig,
+    runtimes: rcRuntimes,
+    userStore: rcUsers,
+    webSessions: rcWS,
+    loginFlows: rcLFM,
+    proxyStore: rcPS,
+    settingsStore: rcSS,
+  })
+  const rcPort = rcServer.address().port
+  const login = async (username) => {
+    const r = await fetch(`http://127.0.0.1:${rcPort}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ username, password: 'secret123' }),
+    })
+    assert.equal(r.status, 200)
+    return r.headers.get('set-cookie').split(';')[0]
+  }
+  const adminCookie = await login('admin')
+  const viewerCookie = await login('viewer')
+
+  // 先 admit 一个活跃 session
+  mockMode = 'ok'
+  sessionPosts = 0
+  sessionDeletes = 0
+  completionAttempts = 0
+  const rcChat = await fetch(`http://127.0.0.1:${rcPort}/v1/chat/completions`, {
+    method: 'POST',
+    headers: { authorization: 'Bearer sk-test', 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'deepseek/deepseek-v4-flash', messages: [{ role: 'user', content: 'hello' }] }),
+  })
+  assert.equal(rcChat.status, 200, await rcChat.clone().text())
+  assert.equal(sessionPosts, 1)
+  assert.equal(rcRuntimes.list()[0].session.status, 'active')
+
+  // 未登录 → 401；非 admin → 403
+  {
+    const anon = await fetch(`http://127.0.0.1:${rcPort}/api/system/reconnect`, { method: 'POST' })
+    assert.equal(anon.status, 401)
+    const viewer = await fetch(`http://127.0.0.1:${rcPort}/api/system/reconnect`, {
+      method: 'POST',
+      headers: { cookie: viewerCookie },
+    })
+    assert.equal(viewer.status, 403)
+  }
+
+  // admin 全部断开重连 → 200，session 被释放（下个请求自动重建）
+  const rcRes = await fetch(`http://127.0.0.1:${rcPort}/api/system/reconnect`, {
+    method: 'POST',
+    headers: { cookie: adminCookie },
+  })
+  assert.equal(rcRes.status, 200, await rcRes.clone().text())
+  const rcJson = await rcRes.json()
+  assert.equal(rcJson.ok, true)
+  assert.equal(rcJson.accounts[0].ok, true)
+  assert.equal(rcRuntimes.list()[0].session.status, 'none', 'reconnect 应释放 session')
+  assert.ok(sessionDeletes >= 1, 'reconnect 应调用上游 DELETE')
+
+  // 下个请求自动重建全新 session
+  const rcChat2 = await fetch(`http://127.0.0.1:${rcPort}/v1/chat/completions`, {
+    method: 'POST',
+    headers: { authorization: 'Bearer sk-test', 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'deepseek/deepseek-v4-flash', messages: [{ role: 'user', content: 'hello' }] }),
+  })
+  assert.equal(rcChat2.status, 200, await rcChat2.clone().text())
+  assert.equal(sessionPosts, 2, `reconnect 后应重新 admit, got ${sessionPosts}`)
+
+  await rcRuntimes.shutdown()
+  rcServer.close()
+  fs.rmSync(rcDir, { recursive: true, force: true })
+  mockMode = 'ok'
 }
 
 // --- 重启 API 端点测试（不执行实际重启）---


### PR DESCRIPTION
## 变更内容

### 1. 负载均衡：账号并发上限可配置（默认 1:1）
- 控制台新增「负载均衡设置」：每账号同时转发的 SSE 响应流数上限（1..16，默认 1），保存立即生效、持久化 `/data/settings.json`，无需重启
- 账号级串行化锁升级为并发信号量：同一账号可同时转发 N 条流（实测同一 `instanceId` 支持并发 chat）；达到上限的请求按热 session 排队，超时换下一个账号
- 监控：总览每个账号新增「并发(在途/上限)」列；`/v1/freebuff/accounts` 行内新增 `inFlight` / `concurrency`

### 2. 全部断开重连（比重启更轻量）
- 右上角新增管理员按钮「全部断开重连」（`POST /api/system/reconnect`）：释放全部账号 session（上游 DELETE）+ 重置并发信号量，用于清理死任务/幽灵连接
- 进程不重启，下一个请求自动 re-admit 全新 session；Web 登录态、账号、代理池不受影响

### 3. 会话临近过期卡顿排查与修复
- 根因：会话剩余时间趋近 0 时仍会被复用承接新请求，请求发到马上过期的会话上、中途卡住
- 修复：新增 `session.re_admit_lead_sec`（默认 60s）——剩余时间低于该值的会话不再承接新请求，先释放旧会话再在本账号 re-admit 续期（不换账号，出口稳定），切换更平滑
- 顺带：流式 idle 超时按会话剩余时间收敛（下限 30s），会话过期后上游不再吐数据会更快被掐断

## 验证
- `npm test`：新增用例（并发上限=2 时同账号最多 2 条并发流 / 近过期会话提前 re-admit 且不换账号 / 全部断开重连 API 的 401·403·释放 session·下个请求自动重建 / 并发信号量单元测试 / 设置 API 校验），全部通过
- `npm run typecheck` 通过；`docker compose config --quiet` 通过
